### PR TITLE
Add complete iOS web app support

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,36 @@
+{
+  "name": "SMWS Codes",
+  "short_name": "SMWS",
+  "description": "A mobile-optimised guide to the distillery codes used by the Scotch Malt Whisky Society",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/images/touch-icon-iphone-57.png",
+      "sizes": "57x57",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/touch-icon-ipad-72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/touch-icon-iphone-114.png",
+      "sizes": "114x114",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/touch-icon-iphone-120.png",
+      "sizes": "120x120",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/touch-icon-ipad-144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,15 @@
-const CACHE_NAME = 'smws-codes-v1';
+const CACHE_NAME = 'smws-codes-v2';
 const urlsToCache = [
   '/',
   '/index.html',
+  '/manifest.json',
   '/css/base.css',
   '/css/leaguegothic-regular-webfont.woff',
+  '/images/touch-icon-iphone-57.png',
+  '/images/touch-icon-ipad-72.png',
+  '/images/touch-icon-iphone-114.png',
+  '/images/touch-icon-iphone-120.png',
+  '/images/touch-icon-ipad-144.png',
   'https://cdn.jsdelivr.net/npm/list.js@2.3.1/dist/list.min.js'
 ];
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,8 +7,18 @@
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="apple-mobile-web-app-title" content="SMWS Codes">
 
     <meta name="description" content="A mobile-optimised guide to the distillery codes used by the Scotch Malt Whisky Society. Add it to your home screen and it will work offline too!">
+
+    <link rel="apple-touch-icon" sizes="57x57" href="/images/touch-icon-iphone-57.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/images/touch-icon-ipad-72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/images/touch-icon-iphone-114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="/images/touch-icon-iphone-120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/images/touch-icon-ipad-144.png">
+
+    <meta name="theme-color" content="#000000">
+    <link rel="manifest" href="/manifest.json">
 
     <title>SMWS Codes</title>
     {% block head %}


### PR DESCRIPTION
## Summary
Adds proper Progressive Web App configuration for iOS devices, enabling the app to function as a standalone web app when added to the home screen.

## Changes
- ✅ Created web app manifest (`public/manifest.json`) with app metadata and icon references
- ✅ Added Apple touch icon links for all existing icon sizes (57, 72, 114, 120, 144)
- ✅ Added `apple-mobile-web-app-title` meta tag for custom home screen name
- ✅ Added theme color meta tag matching app design (#000000)
- ✅ Updated Service Worker to v2, now caches manifest and all icons
- ✅ Added manifest link to HTML template

## Testing
Built and verified locally. All icons and manifest are properly linked and cached.

## Result
The app now functions as a full standalone iOS web app with:
- Proper home screen icons
- No Safari UI when launched from home screen
- Complete offline support
- Professional PWA experience

Note: Current icons are legacy sizes. Modern recommendations are 180×180 (iOS) and 192×192 + 512×512 (Android/PWA), but existing icons will work (iOS scales as needed).